### PR TITLE
Change command executors from singleton objects to instantiated class

### DIFF
--- a/src/main/java/com/mineinabyss/mobzy/Mobzy.kt
+++ b/src/main/java/com/mineinabyss/mobzy/Mobzy.kt
@@ -48,7 +48,7 @@ class Mobzy : JavaPlugin(), MobzyAddon {
         )
 
         //Register commands
-        MobzyCommands
+        MobzyCommands()
 
         registerAddonWithMobzy()
     }

--- a/src/main/java/com/mineinabyss/mobzy/MobzyCommands.kt
+++ b/src/main/java/com/mineinabyss/mobzy/MobzyCommands.kt
@@ -26,7 +26,7 @@ import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
 @ExperimentalCommandDSL
-object MobzyCommands : IdofrontCommandExecutor(), TabCompleter {
+class MobzyCommands : IdofrontCommandExecutor(), TabCompleter {
     override val commands = commands(mobzy) {
         ("mobzy" / "mz") {
             ("reload" / "rl")(desc = "Reloads the configuration files")?.action {


### PR DESCRIPTION
This prevents the executors from being registered for a command before the plugin has been enabled.