### PR TITLE
make tempt take serializable itemstack

### DIFF
--- a/mobzy-pathfinding/src/main/kotlin/com/mineinabyss/mobzy/ecs/goals/minecraft/TemptBehavior.kt
+++ b/mobzy-pathfinding/src/main/kotlin/com/mineinabyss/mobzy/ecs/goals/minecraft/TemptBehavior.kt
@@ -1,27 +1,27 @@
 package com.mineinabyss.mobzy.ecs.goals.minecraft
 
 import com.mineinabyss.idofront.nms.aliases.toNMS
+import com.mineinabyss.idofront.serialization.SerializableItemStack
 import com.mineinabyss.mobzy.ecs.components.initialization.pathfinding.PathfinderComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.minecraft.world.entity.PathfinderMob
 import net.minecraft.world.entity.ai.goal.TemptGoal
 import net.minecraft.world.item.crafting.Ingredient
-import org.bukkit.Material
 import org.bukkit.entity.Mob
 import org.bukkit.inventory.ItemStack
 
 @Serializable
 @SerialName("minecraft:behavior.tempt")
 class TemptBehavior(
-    val items: List<Material>,
-    val speed: Double = 1.0,
-    val losesInterest: Boolean = false
+    private val items: List<SerializableItemStack>,
+    private val speed: Double = 1.0,
+    private val losesInterest: Boolean = false
 ) : PathfinderComponent() {
     override fun build(mob: Mob) = TemptGoal(
         mob.toNMS<PathfinderMob>(),
         speed,
-        items.map { ItemStack(it) }.toNMSRecipeItemStack(),
+        items.map { it.toItemStack() }.toNMSRecipeItemStack(),
         losesInterest,
     )
 }


### PR DESCRIPTION
Seems better than just taking a Material. This also seems to have issues converting to nmsstack as the below error is because "itemstack is null". Example being server-configs ashimite tempt, but also beniguma doesnt have this issue rn?

![image](https://user-images.githubusercontent.com/62521371/185765274-d06daf82-23a1-445c-bfe2-db3d5eebaceb.png)
